### PR TITLE
Add ability to place close button on either left or right

### DIFF
--- a/KGModal.h
+++ b/KGModal.h
@@ -18,19 +18,28 @@ typedef NS_ENUM(NSUInteger, KGModalBackgroundDisplayStyle){
     KGModalBackgroundDisplayStyleSolid
 };
 
+typedef NS_ENUM(NSUInteger, KGModalCloseButtonLocation){
+    KGModalCloseButtonLocationLeft,
+    KGModalCloseButtonLocationRight
+};
+
 @interface KGModal : NSObject
 
 // Determines if the modal should dismiss if the user taps outside of the modal view
 // Defaults to YES
 @property (nonatomic) BOOL tapOutsideToDismiss;
 
-// Determins if the close button or tapping outside the modal should animate the dismissal
+// Determines if the close button or tapping outside the modal should animate the dismissal
 // Defaults to YES
 @property (nonatomic) BOOL animateWhenDismissed;
 
-// Determins if the close button is shown
+// Determines if the close button is shown
 // Defaults to YES
 @property (nonatomic) BOOL showCloseButton;
+
+// Determines whether close button will display on the left or right
+// Defaults to left
+@property (nonatomic) KGModalCloseButtonLocation closeButtonLocation;
 
 // The background color of the modal window
 // Defaults black with 0.5 opacity
@@ -40,13 +49,12 @@ typedef NS_ENUM(NSUInteger, KGModalBackgroundDisplayStyle){
 // Defaults to gradient, this looks better but takes a bit more time to display on the retina iPad
 @property (nonatomic) KGModalBackgroundDisplayStyle backgroundDisplayStyle;
 
-// Determins if the modal should rotate when the device rotates
+// Determines if the modal should rotate when the device rotates
 // Defaults to YES, only applies to iOS5
 @property (nonatomic) BOOL shouldRotate;
 
 // The shared instance of the modal
 + (instancetype)sharedInstance;
-
 
 // Set the content view to display in the modal and display with animations
 - (void)showWithContentView:(UIView *)contentView;

--- a/KGModal.m
+++ b/KGModal.m
@@ -63,6 +63,7 @@ NSString *const KGModalDidHideNotification = @"KGModalDidHideNotification";
     self.shouldRotate = YES;
     self.tapOutsideToDismiss = YES;
     self.animateWhenDismissed = YES;
+    self.closeButtonLocation = KGModalCloseButtonLocationLeft;
     self.showCloseButton = YES;
     self.modalBackgroundColor = [UIColor colorWithWhite:0 alpha:0.5];
     
@@ -114,6 +115,13 @@ NSString *const KGModalDidHideNotification = @"KGModalDidHideNotification";
     self.containerView = containerView;
     
     KGModalCloseButton *closeButton = [[KGModalCloseButton alloc] init];
+    
+    if (self.closeButtonLocation == KGModalCloseButtonLocationRight) {
+        CGRect closeFrame = closeButton.frame;
+        closeFrame.origin.x = containerView.frame.size.width - padding - closeFrame.size.width/2;
+        closeButton.frame = closeFrame;
+    }
+    
     [closeButton addTarget:self action:@selector(closeAction:) forControlEvents:UIControlEventTouchUpInside];
     [closeButton setHidden:!self.showCloseButton];
     [containerView addSubview:closeButton];

--- a/readme.md
+++ b/readme.md
@@ -15,13 +15,17 @@ There are a couple other options but it's purposely designed to be simple and ea
 // Defaults to YES
 @property (nonatomic) BOOL tapOutsideToDismiss;
 
-// Determins if the close button or tapping outside the modal should animate the dismissal
+// Determines if the close button or tapping outside the modal should animate the dismissal
 // Defaults to YES
 @property (nonatomic) BOOL animateWhenDismissed;
 
-// Determins if the close button is shown
+// Determines if the close button is shown
 // Defaults to YES
 @property (nonatomic) BOOL showCloseButton;
+
+// Determines whether close button will display on the left or right
+// Defaults to left
+@property (nonatomic) KGModalCloseButtonLocation closeButtonLocation;
 
 // The background color of the modal window
 // Defaults black with 0.5 opacity


### PR DESCRIPTION
Making the left/right mechanism a 3-prong left/right/none enumeration ended up more awkward than I'd hoped, so I maintained the same show/hide close button functionality and just went with a left/right enumeration, with left as the default.
